### PR TITLE
Expose a Loader-visible wrapping Fiber for the DSH bundle

### DIFF
--- a/dsh-plugin/README.md
+++ b/dsh-plugin/README.md
@@ -1,9 +1,11 @@
 # dsh-plugin-zhihu-search
 
 DeepSeek Harness bundle for
-[`zhihu-search`](https://github.com/klarkxy/zhihu-search). It uses DSH's
-built-in MCP client to launch the pinned Python package over stdio; it does
-not duplicate the Python business logic or store credentials in DSH config.
+[`zhihu-search`](https://github.com/klarkxy/zhihu-search). It mounts a
+package-named wrapper Fiber so Loader can settle `dsh-plugin-zhihu-search`,
+then uses DSH's built-in MCP client to launch the pinned Python package
+over stdio. It does not duplicate the Python business logic or store
+credentials in DSH config.
 
 ## Install
 

--- a/dsh-plugin/cordis.patch.yml
+++ b/dsh-plugin/cordis.patch.yml
@@ -1,6 +1,9 @@
-# DSH ships @deepseek-ai/dsh-mcp-client. This bundle only selects the trusted
-# executable and keeps all Zhihu business logic in the versioned Python package.
+# DSH ships @deepseek-ai/dsh-mcp-client. This bundle keeps Zhihu business
+# logic in the versioned Python package and exposes a package-named wrapper
+# Fiber so Loader can settle dsh-plugin-zhihu-search itself.
 - insert:
+    - id: zhihu-search
+      name: dsh-plugin-zhihu-search
     - id: zhihu-search-mcp
       name: '@deepseek-ai/dsh-mcp-client'
       config:

--- a/dsh-plugin/index.js
+++ b/dsh-plugin/index.js
@@ -1,0 +1,10 @@
+/**
+ * Loader-visible wrapper Fiber for dsh-plugin-zhihu-search.
+ *
+ * The Zhihu tools themselves come from the sibling @deepseek-ai/dsh-mcp-client
+ * insert. This module exists so the reviewed package name has an ACTIVE Fiber
+ * after Loader settle.
+ */
+export const name = 'dsh-plugin-zhihu-search'
+
+export function apply() {}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
   "version": "1.5.0",
   "description": "GitHub-installable DeepSeek Harness bundle for the zhihu-search MCP server",
   "type": "module",
+  "main": "./dsh-plugin/index.js",
+  "exports": {
+    ".": "./dsh-plugin/index.js",
+    "./package.json": "./package.json"
+  },
   "files": [
+    "dsh-plugin/index.js",
     "dsh-plugin/cordis.patch.yml",
     "dsh-plugin/README.md",
     "LICENSE"

--- a/setup/dsh.md
+++ b/setup/dsh.md
@@ -1,8 +1,9 @@
 # DeepSeek Harness
 
-`dsh-plugin-zhihu-search` is a declarative DSH bundle. It inserts DSH's
-built-in `@deepseek-ai/dsh-mcp-client`, which starts the pinned Python MCP
-server over stdio and publishes server-qualified native tools.
+`dsh-plugin-zhihu-search` is a DSH bundle. It inserts a package-named
+wrapper Fiber plus DSH's built-in `@deepseek-ai/dsh-mcp-client`, which
+starts the pinned Python MCP server over stdio and publishes
+server-qualified native tools.
 
 ## Prerequisites
 
@@ -60,7 +61,8 @@ Inspect the composed profile before starting it:
 dsh --profile web --dump-config
 ```
 
-The dump must contain one `zhihu-search-mcp` row using
+The dump must contain one `zhihu-search` row named
+`dsh-plugin-zhihu-search`, plus one `zhihu-search-mcp` row using
 `@deepseek-ai/dsh-mcp-client`, `command: uvx`, the pinned
 `zhihu-search==<version>` package, and `serve --tools compact`. A persistent
 installation requires stopping and restarting the target DSH profile.

--- a/tests/test_dsh_plugin.py
+++ b/tests/test_dsh_plugin.py
@@ -22,7 +22,7 @@ def _manifest() -> dict[str, object]:
     return json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
 
 
-def _plugin_row() -> dict[str, object]:
+def _insert_rows() -> list[dict[str, object]]:
     patch = yaml.safe_load(
         (PLUGIN_DIR / "cordis.patch.yml").read_text(encoding="utf-8")
     )
@@ -30,10 +30,18 @@ def _plugin_row() -> dict[str, object]:
     insert = patch[0]
     assert set(insert) == {"insert"}
     rows = insert["insert"]
-    assert isinstance(rows, list) and len(rows) == 1
-    row = rows[0]
-    assert isinstance(row, dict)
-    return row
+    assert isinstance(rows, list) and len(rows) == 2
+    assert all(isinstance(row, dict) for row in rows)
+    return rows
+
+
+def _row_named(name: str) -> dict[str, object]:
+    rows = {str(row["name"]): row for row in _insert_rows()}
+    return rows[name]
+
+
+def _plugin_row() -> dict[str, object]:
+    return _row_named("@deepseek-ai/dsh-mcp-client")
 
 
 def test_dsh_bundle_manifest_is_git_installable_and_version_locked() -> None:
@@ -45,7 +53,13 @@ def test_dsh_bundle_manifest_is_git_installable_and_version_locked() -> None:
     assert manifest["dsh"] == {
         "bundle": {"patch": "./dsh-plugin/cordis.patch.yml"}
     }
+    assert manifest["main"] == "./dsh-plugin/index.js"
+    assert manifest["exports"] == {
+        ".": "./dsh-plugin/index.js",
+        "./package.json": "./package.json",
+    }
     assert set(manifest["files"]) == {
+        "dsh-plugin/index.js",
         "dsh-plugin/cordis.patch.yml",
         "dsh-plugin/README.md",
         "LICENSE",
@@ -60,6 +74,17 @@ def test_dsh_bundle_manifest_is_git_installable_and_version_locked() -> None:
 
     for filename in manifest["files"]:
         assert (ROOT / filename).is_file()
+
+
+def test_dsh_bundle_exposes_package_named_wrapper_fiber() -> None:
+    wrapper = _row_named("dsh-plugin-zhihu-search")
+    source = (PLUGIN_DIR / "index.js").read_text(encoding="utf-8")
+
+    assert wrapper["id"] == "zhihu-search"
+    assert wrapper["name"] == "dsh-plugin-zhihu-search"
+    assert "config" not in wrapper
+    assert "export const name = 'dsh-plugin-zhihu-search'" in source
+    assert "export function apply() {}" in source
 
 
 def test_dsh_bundle_uses_builtin_mcp_client_and_pinned_python_package() -> None:


### PR DESCRIPTION
## Why

DeepSeek Harness Loader settles the reviewed npm package name. This bundle previously only inserted `@deepseek-ai/dsh-mcp-client`, so `dsh-plugin-zhihu-search` had no ACTIVE Fiber after Loader settle and persistent install failed.

## What

- Insert a package-named wrapper Fiber (`id: zhihu-search`, `name: dsh-plugin-zhihu-search`).
- Add `dsh-plugin/index.js` that exports that Fiber name and an empty `apply()`.
- Keep the existing MCP client insert for the Zhihu tools.
- Update the DSH setup notes and plugin tests.

The Zhihu business logic stays in the pinned Python package. This does not store credentials in DSH config.

## Verify

`dsh --profile web --dump-config` after installing the bundle should show both the wrapper Fiber and `zhihu-search-mcp`.